### PR TITLE
ReadTheDoc URL with - or with _ ???

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Usage Example
 
 Documentation
 =============
-API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/display_emoji_text/en/latest/>`_.
+API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/display-emoji-text/en/latest/>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.


### PR DESCRIPTION
I don't know what is going on, but the documentation link is wrong in the Readme.

I have not compare to other library to know if they use "-" or "_" I just fix this link.