### PR TITLE
fix docs badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Introduction
 
 
 .. image:: https://readthedocs.org/projects/adafruit-circuitpython-display-emoji-text/badge/?version=latest
-    :target: https://docs.circuitpython.org/projects/display_emoji_text/en/latest/
+    :target: https://docs.circuitpython.org/projects/display-emoji-text/en/latest/
     :alt: Documentation Status
 
 


### PR DESCRIPTION
Same fix as #4 essentially, but for the docs badge link instead of the text link further down in the readme.